### PR TITLE
tweak abstract truncation

### DIFF
--- a/fatcat_scholar/templates/search_macros.html
+++ b/fatcat_scholar/templates/search_macros.html
@@ -368,11 +368,11 @@
     </div>
   {% elif paper.abstracts %}
     <div class="search-highlights">
-      {% if paper.abstracts[0].body|length > 500 %}
+      {% if paper.abstracts[0].body|length > 550 %}
         {{ paper.abstracts[0].body | truncate(500, False, '') }}
         <details style="display:inline;">
           <summary>{% trans %}more &raquo;{% endtrans %}</summary>
-          ... {{ paper.abstracts[0].body[480:] }}
+          ... {{ paper.abstracts[0].body[500:] }}
         </details>
       {% else %}
         {{ paper.abstracts[0].body }}


### PR DESCRIPTION
Truncate abstracts longer than 550 chars at the 500 char mark. Previously, abstracts longer than 500 chars were truncated and the last 20 chars were repeated in the spoiler, which imho did not help readability very much:

![image](https://user-images.githubusercontent.com/12068939/153020016-e324b8dd-8b83-47dd-aa4c-c096c9ca5cfa.png)

This should now ensure than there is always enough text in the spoiler and no overly short stubs are truncated.