### PR TITLE
PEP 484 prohibits implicit Optional so mypy has changed its default

### DIFF
--- a/extra/sitemap/generate_sitemap_indices.py
+++ b/extra/sitemap/generate_sitemap_indices.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
 
-import sys
 import glob
 import datetime
+
 
 def index_entity(entity_type, output):
 
     now = datetime.date.today().isoformat()
     print("""<?xml version="1.0" encoding="UTF-8"?>""", file=output)
-    print("""<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""", file=output)
+    print(
+        """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">""",
+        file=output,
+    )
 
     for filename in glob.glob(f"sitemap-{entity_type}-*.txt"):
         print("  <sitemap>", file=output)
@@ -18,11 +21,13 @@ def index_entity(entity_type, output):
 
     print("</sitemapindex>", file=output)
 
+
 def main():
-    with open('sitemap-index-works.xml', 'w') as output:
+    with open("sitemap-index-works.xml", "w") as output:
         index_entity("works", output)
-    with open('sitemap-index-access.xml', 'w') as output:
+    with open("sitemap-index-access.xml", "w") as output:
         index_entity("access", output)
 
-if __name__=="__main__":
+
+if __name__ == "__main__":
     main()

--- a/extra/sitemap/transform_access_url.py
+++ b/extra/sitemap/transform_access_url.py
@@ -2,6 +2,7 @@
 
 import sys
 
+
 # NOTE: copied from fatcat_scholar/hacks.py
 def make_access_redirect_url(work_ident: str, access_type: str, access_url: str) -> str:
     if access_type == "wayback" and "://web.archive.org/" in access_url:
@@ -14,10 +15,12 @@ def make_access_redirect_url(work_ident: str, access_type: str, access_url: str)
     else:
         return access_url
 
+
 def run() -> None:
     for line in sys.stdin:
-        (work_ident, access_type, access_url) = line.strip().split('\t')
+        (work_ident, access_type, access_url) = line.strip().split("\t")
         print(make_access_redirect_url(work_ident, access_type, access_url))
+
 
 if __name__ == "__main__":
     run()

--- a/fatcat_scholar/sim_pipeline.py
+++ b/fatcat_scholar/sim_pipeline.py
@@ -154,7 +154,7 @@ class SimPipeline:
             pages.append(bundle)
         return pages
 
-    def run_issue_db(self, limit: int = None) -> None:
+    def run_issue_db(self, limit: Optional[int] = None) -> None:
         """
         Legacy/Deprecated code path
 

--- a/fatcat_scholar/web_hacks.py
+++ b/fatcat_scholar/web_hacks.py
@@ -41,8 +41,8 @@ class Jinja2Templates:
         name: str,
         context: dict,
         status_code: int = 200,
-        headers: dict = None,
-        media_type: str = None,
+        headers: typing.Optional[dict] = None,
+        media_type: typing.Optional[str] = None,
         background: BackgroundTask = None,
     ) -> _TemplateResponse:
         if "request" not in context:


### PR DESCRIPTION
A change in current versions of `mypy`...
> PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True

Also, `black` and `flake8` fixes.